### PR TITLE
Fix infisical manifests are not cleared upon closing PR

### DIFF
--- a/.github/workflows/pr_clean_up.yaml
+++ b/.github/workflows/pr_clean_up.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: Delete Infisical manifests
       run: |
         cd k8s/bootstrap/infisical-operator/base
-        export SECRET_FILE="secrets/pr-${PR_NUMBER}-infisical-secrets.yaml"
+        export SECRET_FILE="secrets/infisical-secrets-pr-${PR_NUMBER}.yaml"
         rm -f "$SECRET_FILE"
         yq -i 'del(.resources[] | select(. ==  strenv(SECRET_FILE)))' ./kustomization.yaml
       env:


### PR DESCRIPTION
This PR fixes an issue where the PR cleaning up workflow is not deleting infisical manifests due to a mismatch in the naming of the manifests.