### PR TITLE
Fix wrong env while building services

### DIFF
--- a/scripts/docker/build-services.sh
+++ b/scripts/docker/build-services.sh
@@ -3,7 +3,7 @@
 # Exit on failure
 set -eo pipefail
 
-ENV="staging"
+ENV="${ENV:-staging}"
 
 while getopts let:c:h OPTS; do
   case $OPTS in


### PR DESCRIPTION
Fixed a bug that causes env variable provided by the CI to be overriden during the building step.