### PR TITLE
Allow E2E testing in CI for production

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,15 +139,6 @@ jobs:
     needs: [build_app, update_backend_manifest]
     if: >-
       always() && 
-      (
-        github.event.inputs.DEPLOY_ENV
-        || (
-          github.ref_name == 'master' && 'production'
-          || github.ref_name == 'staging'
-             && (github.event_name == 'push' && 'staging' || 'dev')
-          || 'dev'
-        )
-      ) != 'production' &&
       (needs.build_app.result == 'success' || needs.build_app.result == 'skipped') && 
       (needs.update_backend_manifest.result == 'success' || needs.update_backend_manifest.result == 'skipped') && 
       !(needs.build_app.result == 'skipped' && needs.update_backend_manifest.result == 'skipped')
@@ -287,18 +278,9 @@ jobs:
   website_test:
     name: Website E2E tests
     runs-on: ubuntu-latest
-    needs: update_backend_manifest
+    needs: [update_backend_manifest]
     if: >-
       always() &&
-      (
-        github.event.inputs.DEPLOY_ENV
-        || (
-          github.ref_name == 'master' && 'production'
-          || github.ref_name == 'staging'
-             && (github.event_name == 'push' && 'staging' || 'dev')
-          || 'dev'
-        )
-      ) != 'production' &&
       needs.update_backend_manifest.result == 'success'
     permissions:
       contents: write


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to enable E2E tests for mobile and website across all deployment environments, previously restricted in production scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Carl-Johnsons/tastopia/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->