### PR TITLE
Fix stale ci dev builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,7 +223,8 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
-            bash ./scripts/ci/test/install-app.sh
+            MOBILE_TAG=$(printf "%s\n" "${SERVICES}" | grep -o "mobile:[^ ]*" | cut -d: -f2 | head -n1 || true)
+            bash ./scripts/ci/test/install-app.sh -t "$MOBILE_TAG"
             bash ./scripts/ci/test/test-e2e.sh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -556,10 +557,6 @@ jobs:
           fi
 
           echo "Updating $SERVICE..."
-
-          if [ "$SERVICE" = "website" ]; then
-            TAG="${ENV}-${TAG}"
-          fi
 
           IMAGE="ghcr.io/carl-johnsons/tastopia-${SERVICE}:${TAG}"
           BEFORE_CHECKSUM="$(sha256sum "$VALUES_FILE" | cut -d ' ' -f 1)"

--- a/scripts/ci/build/build-app.sh
+++ b/scripts/ci/build/build-app.sh
@@ -13,7 +13,7 @@ ENV="${ENV:-dev}"
 
 bucket_name="tastopia-builds"
 
-commit=""
+tag=""
 
 while getopts e:ht: OPTS; do
   case $OPTS in
@@ -25,7 +25,7 @@ while getopts e:ht: OPTS; do
 
       ENV="$OPTARG"
       ;;
-    t) commit="$OPTARG" ;;
+    t) tag="$OPTARG" ;;
     h) cat <<EOF
 
 Usage: $0 [options]
@@ -37,7 +37,7 @@ Options:
         the default value is "staging".
 
   -t [tag]
-        Explicitly specify the commit tag to use for the build.
+        Explicitly specify the tag to use for the build.
 
   -h    Print this help.
 
@@ -53,12 +53,18 @@ done
 
 shift $((OPTIND - 1))
 
-if [ -z "$commit" ]; then
-  commit=$(git log -n 1 --pretty=format:%H -- app/client/mobile | cut -c1-8)
+if [ -z "$tag" ]; then
+  commit_hash=$(git log -n 1 --pretty=format:%H -- app/client/mobile | cut -c1-8)
+
+  if [ "$ENV" = "dev" ]; then
+    : "${PR_NUMBER:?PR_NUMBER env value is required for dev environment}"
+    file_name="build-$ENV-$PR_NUMBER-$commit_hash.apk"
+  else
+    file_name="build-$ENV-$commit_hash.apk"
+  fi
+else
+  file_name="build-${tag}.apk"
 fi
-
-file_name="build-$ENV-$commit.apk"
-
 
 is_build_exists() {
   if ! aws s3api head-bucket --bucket "$bucket_name" >/dev/null 2>&1; then

--- a/scripts/ci/build/derive-service-state.py
+++ b/scripts/ci/build/derive-service-state.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 
 import argparse
+import os
 import subprocess
 from dataclasses import dataclass, field
 from enum import StrEnum
 from functools import cache
+
+_ENV = os.environ.get("ENV")
+_PR_NUMBER = os.environ.get("PR_NUMBER")
 
 
 class ServiceName(StrEnum):
@@ -32,6 +36,7 @@ class Service:
     paths: tuple[str, ...]
     dependencies: tuple["Service", ...] = field(default_factory=tuple)
     exclude_paths: tuple[str, ...] = field(default_factory=tuple)
+    isClient: bool = False
 
 
 contract = Service(ServiceName.CONTRACT, ("app/server/Contract",))
@@ -42,8 +47,14 @@ website = Service(
         "app/client/website/cypress/**",
         "app/client/website/cypress.config.ts",
     ),
+    isClient=True,
 )
-mobile = Service(ServiceName.MOBILE, ("app/client/mobile",), exclude_paths=("app/client/mobile/.maestro",))
+mobile = Service(
+    ServiceName.MOBILE,
+    ("app/client/mobile",),
+    exclude_paths=("app/client/mobile/.maestro",),
+    isClient=True,
+)
 api_gateway = Service(ServiceName.API_GATEWAY, ("app/server/APIGateway",), (contract,))
 signalr = Service(ServiceName.SIGNALR, ("app/server/SignalRService",), (contract,))
 tracking_api = Service(
@@ -97,7 +108,9 @@ push_worker = Service(
     (contract,),
 )
 recipe_worker = Service(
-    ServiceName.RECIPE_WORKER, ("app/server/RecipeService/src/RecipeWorker",), (contract,)
+    ServiceName.RECIPE_WORKER,
+    ("app/server/RecipeService/src/RecipeWorker",),
+    (contract,),
 )
 
 all_services: tuple[Service, ...] = (
@@ -139,7 +152,7 @@ def get_exclude_paths(service: Service) -> frozenset[str]:
     return frozenset(exclude_paths)
 
 
-def get_latest_service_tag(service: Service, tag_length: int = 8) -> str:
+def _get_latest_service_tag(service: Service, tag_length: int = 8) -> str:
     """
     Returns the latest tag based on the current state of the Git commit tree.
 
@@ -158,6 +171,43 @@ def get_latest_service_tag(service: Service, tag_length: int = 8) -> str:
     ).stdout[:tag_length]
 
     return latest_sha
+
+
+def get_tag(service: Service, tag_length: int = 8) -> str:
+    """
+    Returns the latest tag based on the current state of the Git commit tree and
+    the current build environment.
+
+    Args:
+        service - The targeted service
+        tag_length - The length of the tag result
+    """
+    tag = ""
+
+    if not service.isClient:
+        return _get_latest_service_tag(service, tag_length)
+
+    if not (_ENV and _PR_NUMBER):
+        raise RuntimeError(f"""
+        Either ENV or PR_NUMBER has to be specified to get tag of {service.name.name} service
+                           """)
+
+    if (not _ENV or _ENV == "dev") and not _PR_NUMBER:
+        raise RuntimeError(
+            f"PR_NUMBER has to be specified to get a unique dev tag for {service.name.value}"
+        )
+
+    if _ENV:
+        tag += f"{_ENV}-"
+    elif _PR_NUMBER:
+        tag += "dev-"
+
+    if _PR_NUMBER and (not _ENV or _ENV == "dev"):
+        tag += f"{_PR_NUMBER}-"
+
+    tag += _get_latest_service_tag(service, tag_length)
+
+    return tag
 
 
 def get_service_by_name(service_name: ServiceName) -> Service:
@@ -212,7 +262,7 @@ def main():
         services = all_services
 
     for service in services:
-        tag = get_latest_service_tag(service=service, tag_length=args.tag_length)
+        tag = get_tag(service=service, tag_length=args.tag_length)
         if not tag:
             continue
 

--- a/scripts/ci/test/install-app.sh
+++ b/scripts/ci/test/install-app.sh
@@ -3,11 +3,12 @@
 set -euo pipefail
 
 ENV="${ENV:-dev}"
+tag=""
 
 script_dir=$(cd -- $(dirname -- "${BASH_SOURCE[0]}") && pwd)
 bucket_name="tastopia-builds"
 
-while getopts e:h OPTS; do
+while getopts e:ht: OPTS; do
   case $OPTS in
   e)
     if [ "$OPTARG" != "dev" ] && [ "$OPTARG" != "staging" ] && [ "$OPTARG" != "production" ]; then
@@ -17,6 +18,7 @@ while getopts e:h OPTS; do
 
     ENV="$OPTARG"
     ;;
+  t) tag="$OPTARG" ;;
   h)
     cat <<EOF
 
@@ -28,13 +30,16 @@ Options:
         are "dev", "staging" or "production". If omitted, 
         the default value is "staging".
 
+  -t [tag]
+        Explicitly specify the tag used for the build artifact.
+
   -h    Print this help.
 
 EOF
     exit 0
     ;;
   ?)
-    echo "Unknown flag. Usage: $0 [-e dev|staging|production]"
+    echo "Unknown flag. Usage: $0 [-t tag] [-e dev|staging|production]"
     exit 1
     ;;
   esac
@@ -42,8 +47,18 @@ done
 
 shift $((OPTIND - 1))
 
-commit=$(git log -n 1 --pretty=format:%H -- app/client/mobile | cut -c1-8)
-file_name="build-$ENV-$commit.apk"
+if [ -n "$tag" ]; then
+  file_name="build-${tag}.apk"
+else
+  commit=$(git log -n 1 --pretty=format:%H -- app/client/mobile | cut -c1-8)
+
+  if [ "$ENV" = "dev" ]; then
+    : "${PR_NUMBER:?PR_NUMBER env value is required for dev environment}"
+    file_name="build-$ENV-$PR_NUMBER-$commit.apk"
+  else
+    file_name="build-$ENV-$commit.apk"
+  fi
+fi
 
 install_app() {
   adb -e install -r "$script_dir/../../../$file_name"

--- a/scripts/ci/test/install-testing-deps.sh
+++ b/scripts/ci/test/install-testing-deps.sh
@@ -49,7 +49,12 @@ done
 shift $((OPTIND - 1))
 
 commit=$(git log -n 1 --pretty=format:%H -- app/client/mobile | cut -c1-8)
-file_name="build-$ENV-$commit.apk"
+if [ "$ENV" = "dev" ]; then
+  : "${PR_NUMBER:?PR_NUMBER env value is required for dev environment}"
+  file_name="build-$ENV-$PR_NUMBER-$commit.apk"
+else
+  file_name="build-$ENV-$commit.apk"
+fi
 
 install_maestro() {
   if command -v maestro-runner >/dev/null 2>&1 && maestro-runner --version | grep -q "$MAESTRO_VERSION"; then

--- a/scripts/docker/build-services.sh
+++ b/scripts/docker/build-services.sh
@@ -261,16 +261,9 @@ build_services() {
       continue
     fi
 
-    commitHash="${image#*:}"
+    service_tag="${image#*:}"
     serviceRepo=${repo}-${service}
-
-    if [ "$service" = "website" ]; then
-      tag="${ENV}-${commitHash}"
-    else
-      tag="${commitHash}"
-    fi
-
-    image="${serviceRepo}:${tag}"
+    image="${serviceRepo}:${service_tag}"
 
     if is_real_image "$image"; then
       echo "Image ${image} already exists in the container registry → skipping build and push"


### PR DESCRIPTION
The build currently does not differenciate between pr builds, making the new pr ci process think that the artifacts are already built and reuse the old artifacts from the old PRs.

This PR fixes that issue by changing the naming convention of built artifacts for:
- Production and staging: `<service>:<ENV>-<COMMIT_HASH>`
- Dev (PR): `<service>:<ENV>-<PR_NUMBER>-<COMMIT_HASH>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow for mobile app builds to use explicit service tags derived from environment and PR information.
  * Refactored build artifact naming conventions for improved consistency across development and production environments.
  * Enhanced service tagging logic to differentiate between client and non-client services in the deployment pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->