### PR TITLE
fix: trust auth headers to allow PKCE flow behind a reverse proxy

### DIFF
--- a/app/client/website/src/auth.ts
+++ b/app/client/website/src/auth.ts
@@ -9,6 +9,7 @@ import {
 import { v4 as uuidv4 } from "uuid";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
+  trustHost: true,
   providers: [
     DuendeIDS6Provider({
       clientId: DUENDE_IDS6_ID as string,


### PR DESCRIPTION
Trust auth host to properly use the attached forwarded headers from reverse proxies.