### PR TITLE
fix(website): trust host in NextAuth config for PKCE auth flow behind a reverse proxy

### DIFF
--- a/app/client/website/src/auth.ts
+++ b/app/client/website/src/auth.ts
@@ -6,7 +6,6 @@ import {
   DUENDE_IDS6_ISSUER,
   SCOPE
 } from "./constants/api";
-import { v4 as uuidv4 } from "uuid";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   trustHost: true,
@@ -22,7 +21,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         url: `${DUENDE_IDS6_ISSUER}/connect/authorize`,
         params: {
           scope: SCOPE,
-          nonce: uuidv4(),
           redirect_uri: `${CLIENT_BASE_URL}/api/auth/callback/duende-identity-server6`
         }
       },

--- a/app/client/website/src/auth.ts
+++ b/app/client/website/src/auth.ts
@@ -9,6 +9,7 @@ import {
 import { v4 as uuidv4 } from "uuid";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
+  trustHost: true,
   providers: [
     DuendeIDS6Provider({
       clientId: DUENDE_IDS6_ID as string,

--- a/app/client/website/src/auth.ts
+++ b/app/client/website/src/auth.ts
@@ -9,6 +9,18 @@ import {
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
   trustHost: true,
+  debug: process.env.NODE_ENV !== "production",
+  logger: {
+    error(code, ...metadata) {
+      console.error(`[NextAuth Error] ${code}`, ...metadata);
+    },
+    warn(code, ...metadata) {
+      console.warn(`[NextAuth Warn] ${code}`, ...metadata);
+    },
+    debug(code, ...metadata) {
+      console.debug(`[NextAuth Debug] ${code}`, ...metadata);
+    }
+  },
   providers: [
     DuendeIDS6Provider({
       clientId: DUENDE_IDS6_ID as string,


### PR DESCRIPTION
Trust auth host to properly use the attached forwarded headers from reverse proxies.
